### PR TITLE
Fixing the Ladder tutorial for testing v5.9

### DIFF
--- a/Tutorials/OlympicsLadderChallenge.arcTutorial2
+++ b/Tutorials/OlympicsLadderChallenge.arcTutorial2
@@ -54,6 +54,7 @@ function main()
 	--clearTerrain(1950,950)
         --give seas fam 
         game.getUser().increaseFamiliarLevel(Book.Seas,false, true)
+        game.getUser().removeSpell("Brine Burst")
         game.getUser().addSpell("Summon Storm Spirit")
         game.getUser().addSpell("Summon Dark Knight")
         game.getUser().addSpell("Flight")

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 ArcanistsTetris, v1
 NapalmGame, v1
 OlympicsCrystalsRun, v1
-OlympicsLadderChallenge, v1
+OlympicsLadderChallenge, v2, Testingv5.9
 Real_Time_Combat, v1
 tutorialTemplate, v1


### PR DESCRIPTION
The familiar spells added in one of the recent versions caused this tutorial to fail to start. Added a single line to remove this spell after giving the familiar.